### PR TITLE
Consider a move to gradle?

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,25 @@
+apply plugin: 'java'
+apply plugin: 'idea'
+
+sourceSets {
+  main {
+    java {
+      srcDir 'src'
+    }
+  }
+  test {
+    java {
+      srcDir 'test'
+    }
+  }
+}
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  testCompile 'junit:junit:4.10'
+  testCompile 'org.mockito:mockito-core:1.9.5-rc1'
+}
+


### PR DESCRIPTION
Hi Saleem,

Attempting to run `ant` on a freshly-cloned copy of your project, I got this error:

``` shell
BUILD FAILED
~/development/opensource/GenericObserver/build.xml:183: /System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home does not exist.
```

I looked to fix this briefly, but then figured it'd take just as long to get a simple gradle file together. I wondered if you might consider a move to gradle for the project? 

I included a build file that runs all the tests with the same library versions as the lib directory with `gradle test` and generates intellij project files with `gradle idea`.

Let me know what you think :)
